### PR TITLE
Add features to support cartouches

### DIFF
--- a/pona/fuckshitpiss.js
+++ b/pona/fuckshitpiss.js
@@ -80,6 +80,11 @@ function makeUnknownCard(word) {
         }
     }
 
+    // if it would be a valid word if it were lowercased, use the lowercase version
+    const lowercaseWord = word.toLowerCase();
+    if (tokipona[lowercaseWord] !== undefined) {
+        return makeWordCard(tokipona[lowercaseWord]);
+    }
 
     const newCard = document.createElement('div');
     newCard.className = 'word-card';

--- a/pona/style.css
+++ b/pona/style.css
@@ -11,6 +11,15 @@ i dont know if its different from using html? so im just going with the usual lm
 @font-face {
     font-family: 'nishiki'; src: url('/fonts/nishiki-teki-lili.ttf');
 }
+
+.highlightOnHover {
+    cursor: pointer;
+}
+
+.highlightOnHover:hover {
+    color:#ffed91;
+}
+
 .sitelen {
     font-family: "nishiki";
     font-style: normal;
@@ -18,6 +27,13 @@ i dont know if its different from using html? so im just going with the usual lm
     font-size: xx-large;
     color: #ffffff;
     padding-right: 5px;
+    /* unselectable */
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 body {


### PR DESCRIPTION
This change adds support for proper nouns. If a word has the first letter capitalized, then the new feature is used -- even if it is otherwise a valid word. (Also, you can customize the cartouche by clicking individual letters in the cartouche. This is saved into local storage, so that randomization does not affect it until you reset it.)

<img width="1370" height="881" alt="image" src="https://github.com/user-attachments/assets/ac35cc14-1e58-453f-8d18-51529c7d56c4" />

If other letters are capitalized, but not the first, then it's treated as a regular word:

<img width="1093" height="570" alt="image" src="https://github.com/user-attachments/assets/2ead9b1e-e0a4-4bba-9533-b6efb702b72c" />

If the first letter is capitalized, but there are invalid letters (aka those that cannot be mapped to cartouche symbols), then there's a custom message for that.

<img width="1183" height="586" alt="image" src="https://github.com/user-attachments/assets/e88cbfbf-f990-42da-a84b-776d6125e94d" />
